### PR TITLE
Clarify auto uploading

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Downloads are available on the <a href='https://github.com/bluegill/katana/relea
 
 ### Features
 * Upload to several different image hosts, including Imgur and Pomf.
+* Automatically upload when screenshot is taken.
 * Directly upload files by dragging & dropping them onto the menubar.
 * Shorten any link that's copied to your clipboard.
 * Customizable shortcuts and preferences.


### PR DESCRIPTION
Make it more obvious to new users that this app offers automatic uploading when a screenshot is taken.

A lot of other apps offer drag/drop upload of files but few of them trigger upload/copy to clipboard when a screenshot is taken using the native macOS screenshot tool like this one does.